### PR TITLE
Generalize `dataFromJson` to allow JSON lists

### DIFF
--- a/src/VegaLite.elm
+++ b/src/VegaLite.elm
@@ -2157,7 +2157,8 @@ general cases of json creation, consider
 
     let
         geojson =
-            geometry (GeoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 59 ) ] ]) []
+            [ geometry (GeoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 59 ) ] ]) [] ]
+                |> JE.list
     in
     toVegaLite
         [ width 200
@@ -2171,11 +2172,11 @@ general cases of json creation, consider
 dataFromJson : Spec -> List Format -> Data
 dataFromJson json fmts =
     if fmts == [] then
-        ( VLData, JE.object [ ( "values", JE.list [ json ] ) ] )
+        ( VLData, JE.object [ ( "values", json ) ] )
     else
         ( VLData
         , JE.object
-            [ ( "values", JE.list [ json ] )
+            [ ( "values", json )
             , ( "format", JE.object (List.concatMap formatProperty fmts) )
             ]
         )


### PR DESCRIPTION
I am experimenting with `elm-vega` and found it counterintuitive that `dataFromJson` wraps the JSON value into another list.

I think it is better to just assume that the JSON value is already a list. This allows passing complete datasets with all fields defined, which is currently not possible. To support the current usage, single values can simply be wrapped into a JSON list before passing them to `dataFromJson`.

Please see if this change makes sense to you.