### PR TITLE
Add UTC versions of TimeUnit

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "2.1.0",
-    "summary": "Declarative visualization with Elm and Vega / Vega-Lite",
-    "repository": "https://github.com/gicentre/elm-vega.git",
+    "summary": "(Fork of) Declarative visualization with Elm and Vega / Vega-Lite",
+    "repository": "https://github.com/jeffesp/elm-vega.git",
     "license": "BSD3",
     "source-directories": [
         "./src/"

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "3.0.0",
+    "version": "1.0.0",
     "summary": "(Fork of) Declarative visualization with Elm and Vega / Vega-Lite",
-    "repository": "https://www.nexosisdev.com/jeffesp/elm-vega.git",
+    "repository": "https://github.com/jeffesp/elm-vega.git",
     "license": "BSD3",
     "source-directories": [
         "./src/"

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "2.1.0",
+    "version": "3.0.0",
     "summary": "(Fork of) Declarative visualization with Elm and Vega / Vega-Lite",
-    "repository": "https://github.com/jeffesp/elm-vega.git",
+    "repository": "https://www.nexosisdev.com/jeffesp/elm-vega.git",
     "license": "BSD3",
     "source-directories": [
         "./src/"

--- a/src/VegaLite.elm
+++ b/src/VegaLite.elm
@@ -1763,6 +1763,29 @@ type
     | Seconds
     | SecondsMilliseconds
     | Milliseconds
+    | UtcYear
+    | UtcYearQuarter
+    | UtcYearQuarterMonth
+    | UtcYearMonth
+    | UtcYearMonthDate
+    | UtcYearMonthDateHours
+    | UtcYearMonthDateHoursMinutes
+    | UtcYearMonthDateHoursMinutesSeconds
+    | UtcQuarter
+    | UtcQuarterMonth
+    | UtcMonth
+    | UtcMonthDate
+    | UtcDate
+    | UtcDay
+    | UtcHours
+    | UtcHoursMinutes
+    | UtcHoursMinutesSeconds
+    | UtcMinutes
+    | UtcMinutesSeconds
+    | UtcSeconds
+    | UtcSecondsMilliseconds
+    | UtcMilliseconds
+
 
 
 {-| Title configuration properties. These are used to configure the default style
@@ -5768,6 +5791,71 @@ timeUnitLabel tu =
         Milliseconds ->
             "milliseconds"
 
+        UtcYear ->
+            "utcyear"
+
+        UtcYearQuarter ->
+            "utcyearquarter"
+
+        UtcYearQuarterMonth ->
+            "utcyearquartermonth"
+
+        UtcYearMonth ->
+            "utcyearmonth"
+
+        UtcYearMonthDate ->
+            "utcyearmonthdate"
+
+        UtcYearMonthDateHours ->
+            "utcyearmonthdatehours"
+
+        UtcYearMonthDateHoursMinutes ->
+            "utcyearmonthdatehoursminutes"
+
+        UtcYearMonthDateHoursMinutesSeconds ->
+            "utcyearmonthdatehoursminutesseconds"
+
+        UtcQuarter ->
+            "utcquarter"
+
+        UtcQuarterMonth ->
+            "utcquartermonth"
+
+        UtcMonth ->
+            "utcmonth"
+
+        UtcMonthDate ->
+            "utcmonthdate"
+
+        UtcDate ->
+            "utcdate"
+
+        UtcDay ->
+            "utcday"
+
+        UtcHours ->
+            "utchours"
+
+        UtcHoursMinutes ->
+            "utchoursminutes"
+
+        UtcHoursMinutesSeconds ->
+            "utchoursminutesseconds"
+
+        UtcMinutes ->
+            "utcminutes"
+
+        UtcMinutesSeconds ->
+            "utcminutesseconds"
+
+        UtcSeconds ->
+            "utcseconds"
+
+        UtcSecondsMilliseconds ->
+            "utcsecondsmilliseconds"
+
+        UtcMilliseconds ->
+            "utcmilliseconds"
 
 titleConfigSpec : TitleConfig -> LabelledSpec
 titleConfigSpec titleCfg =


### PR DESCRIPTION
This isn't the prettiest change, but it seems to work in my local testing. 

I'm unable to generate accurate graphs without it. 