### PR TITLE
Minor documentation fixes.

### DIFF
--- a/src/VegaLite.elm
+++ b/src/VegaLite.elm
@@ -522,7 +522,7 @@ type APosition
     | AEnd
 
 
-{-| Idenfies whether a repeated/faceted view is arranged in rows or columns.
+{-| Identifies whether a repeated/faceted view is arranged in rows or columns.
 -}
 type Arrangement
     = Column
@@ -2943,7 +2943,7 @@ to apply to each of those fields using `asSpec`.
     spec = ...
     toVegaLite
         [ repeat [ ColumnFields [ "Cat", "Dog", "Fish" ] ]
-        , ( Spec, asSpec spec )
+        , specification (asSpec spec)
         ]
 
 See the [Vega-Lite documentation](https://vega.github.io/vega-lite/docs/repeat.html)


### PR DESCRIPTION
Address a type and change an example to use a function to create the
(VLProperty, Spec) pair rather than being explicit.