### PR TITLE
Export FieldTitleProperty

### DIFF
--- a/src/VegaLite.elm
+++ b/src/VegaLite.elm
@@ -24,6 +24,7 @@ module VegaLite
         , DetailChannel(..)
         , FacetChannel(..)
         , FacetMapping(..)
+        , FieldTitleProperty(..)
         , Filter(..)
         , FilterRange(..)
         , FontWeight(..)
@@ -495,7 +496,7 @@ to the data and transform options described above.
 @docs APosition
 @docs ViewConfig
 @docs RangeConfig
-
+@docs FieldTitleProperty
 
 # General Data types
 


### PR DESCRIPTION
I added it to the "Global Configuration" section of the docs as a guess.

I noticed this (and the other doc fixes I've added recently) when porting your module to Haskell - https://hackage.haskell.org/package/hvega-0.1.0.0 